### PR TITLE
fix: pin openstacksdk 4.14.0 for 2025.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ sed -i '/glance_store/d' /upper-constraints.txt
 sed -i '/horizon/d' /upper-constraints.txt
 sed -i '/networking-generic-switch/d' /upper-constraints.txt
 sed -i '/tap-as-a-service/d' /upper-constraints.txt
+sed -i 's/^openstacksdk===.*/openstacksdk===4.14.0/' /upper-constraints.txt
 sed -i 's/^XStatic-Angular-Bootstrap===.*/XStatic-Angular-Bootstrap===2.5.0.1/' /upper-constraints.txt
 sed -i 's/^XStatic-Angular-FileUpload===.*/XStatic-Angular-FileUpload===12.2.13.2/' /upper-constraints.txt
 sed -i 's/^XStatic-Angular-Gettext===.*/XStatic-Angular-Gettext===2.4.1.1/' /upper-constraints.txt


### PR DESCRIPTION
## Summary

- override the `stable/2025.1` upper constraint for `openstacksdk` to `4.14.0`
- match the version currently used by the `main` branch constraints
- ensure 2025.1 images include the Neutron `tenant_id` port server-side filter fix from openstacksdk

## Context

`stable/2025.1` currently inherits `openstacksdk===4.4.0` from `openstack/requirements`, while `main` resolves to `openstacksdk===4.14.0`. The older SDK can cause Horizon/OpenStackSDK to fetch all Neutron ports when `tenant_id` is used, which makes Horizon floating-IP and instance-page paths very slow at scale.

Related: vexxhost/atmosphere#4000

## Testing

- not run locally; Docker image build should validate the constraints during CI